### PR TITLE
Fix CFG builder call handling for subscripts

### DIFF
--- a/python/cfg_builder.py
+++ b/python/cfg_builder.py
@@ -288,7 +288,12 @@ class CFGBuilder(ast.NodeVisitor):
             elif type(node) == ast.Str:
                 return node.s
             elif type(node) == ast.Subscript:
-                return node.value.id
+                # For subscript expressions, attempt to recursively
+                # retrieve the base object's name to avoid attribute
+                # errors when nested attributes are used.
+                if hasattr(node.value, 'id'):
+                    return node.value.id
+                return visit_func(node.value)
             else:
                 return type(node).__name__
 


### PR DESCRIPTION
## Summary
- handle nested `Attribute` nodes inside `Subscript` when collecting call names in `CFGBuilder`

## Testing
- `python - <<'EOF'
from python.cfg_builder import CFGBuilder
code = '''def get(self, peer_id: ID, key: str) -> Any:
    if peer_id in self.peer_data_map:
        try:
            val = self.peer_data_map[peer_id].get_metadata(key)
        except PeerDataError as error:
            raise PeerStoreError() from error
        return val
    raise PeerStoreError("peer ID not found")
'''
cfg = CFGBuilder().build_from_src('test', code)
print(cfg)
EOF`
- `python - <<'EOF'
from python.cfg_builder import CFGBuilder
cfg = CFGBuilder().build_from_file('test_python', 'snippet_python')
cfg.build_visual('cfg_python','pdf', calls=False, show=False)
print(cfg)
EOF`


------
https://chatgpt.com/codex/tasks/task_e_685b52edea60833083042ecce2e81fa2