### PR TITLE
Fix CFG build on unconditional Rust loops

### DIFF
--- a/rust/cfg_builder.py
+++ b/rust/cfg_builder.py
@@ -225,13 +225,19 @@ class CFGBuilder:
         self.current_block = loop_guard
         self.add_statement(self.current_block, node)
         cond = node.child_by_field_name('condition')
-        cond_text = self.get_text(cond)
+        cond_text = self.get_text(cond) if cond else None
         self.curr_loop_guard_stack.append(loop_guard)
         while_block = self.new_block()
-        self.add_exit(self.current_block, while_block, cond_text)
-        after_while = self.new_block()
-        self.after_loop_block_stack.append(after_while)
-        self.add_exit(self.current_block, after_while, self.invert(cond_text))
+        if cond_text:
+            self.add_exit(self.current_block, while_block, cond_text)
+            after_while = self.new_block()
+            self.after_loop_block_stack.append(after_while)
+            self.add_exit(self.current_block, after_while, self.invert(cond_text))
+        else:
+            self.add_exit(self.current_block, while_block)
+            after_while = self.new_block()
+            self.after_loop_block_stack.append(after_while)
+            self.add_exit(self.current_block, after_while)
         self.current_block = while_block
         body = node.child_by_field_name('body')
         if body.type in ('block', 'compound_statement'):


### PR DESCRIPTION
## Summary
- handle `loop` expressions in Rust CFG builder

## Testing
- `pip install -e .`
- `python -m compileall -q .`
- `python - <<'PY'
from rust.cfg_builder import CFGBuilder
cfg = CFGBuilder().build_from_file('test_rust', 'snippet_rust')
print('CFG built', cfg)
PY`

------
https://chatgpt.com/codex/tasks/task_e_685d484553f48330b8e41454aaed0555