### PR TITLE
Add JavaScript CFG support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,18 @@ Java builder: if the appropriate tree-sitter bindings are installed they will be
 used, otherwise a simple line based parser provides a fallback. Usage mirrors
 the Java example; import the desired language package (`rust`, `go` or `c`) and
 call `CFGBuilder().build_from_file()` on your source file.
+
+## JavaScript Support
+
+A basic CFG builder for JavaScript is also available. Usage mirrors the Java
+example:
+
+```python
+from javascript import CFGBuilder
+
+cfg = CFGBuilder().build_from_file('example.js', './example.js')
+cfg.build_visual('example_js_cfg.dot', 'pdf')
+```
+
+Like the other builders, it relies on Tree-sitter for parsing when available and
+falls back to a very simple line based parser otherwise.

--- a/javascript/__init__.py
+++ b/javascript/__init__.py
@@ -1,0 +1,2 @@
+from .cfg_builder import CFGBuilder
+from .model import Block, Link, CFG

--- a/javascript/cfg_builder.py
+++ b/javascript/cfg_builder.py
@@ -1,0 +1,299 @@
+"""CFG builder for JavaScript using tree-sitter.
+
+The implementation mirrors the Java builder. When ``tree_sitter`` and the
+``tree_sitter_javascript`` bindings are available a proper parser is used.  If
+not, the builder falls back to a very naive line based parser so that tests
+depending on basic functionality still run.
+"""
+from .model import Block, Link, CFG
+try:
+    from tree_sitter import Language, Parser
+    import tree_sitter_javascript as tsjs
+except Exception:  # pragma: no cover - optional dependency
+    Language = None
+    Parser = None
+    tsjs = None
+
+try:  # Newer wheels ship a helper returning a ready-made parser
+    from tree_sitter_languages import get_parser as ts_get_parser
+except Exception:  # pragma: no cover - optional dependency
+    ts_get_parser = None
+
+
+class CFGBuilder:
+    def __init__(self, separate=False):
+        self.after_loop_block_stack = []
+        self.after_switch_block_stack = []
+        self.curr_loop_guard_stack = []
+        self.current_block = None
+        self.separate_node_blocks = separate
+        self.src = ""
+        # ``tree_sitter_languages`` or ``tree_sitter_javascript`` may not be installed
+        # or compatible. Try to obtain a parser and fall back to ``None`` on
+        # failure so that tests relying on the simple fallback still run.
+
+        try:
+            if Language is not None and Parser is not None and tsjs is not None:
+                LANGUAGE = Language(tsjs.language())
+                self.parser = Parser(LANGUAGE)
+            else:
+                self.parser = None
+        except Exception:  # pragma: no cover - handled in tests
+            self.parser = None
+
+    # Graph management
+    def new_block(self):
+        self.current_id += 1
+        return Block(self.current_id)
+
+    def add_statement(self, block, statement):
+        block.statements.append(statement)
+
+    def add_exit(self, block, nextblock, exitcase=None):
+        newlink = Link(block, nextblock, exitcase)
+        block.exits.append(newlink)
+        nextblock.predecessors.append(newlink)
+
+    def new_loopguard(self):
+        if self.current_block.is_empty() and len(self.current_block.exits) == 0:
+            loopguard = self.current_block
+        else:
+            loopguard = self.new_block()
+            self.add_exit(self.current_block, loopguard)
+        return loopguard
+
+    # Build methods
+    def build_from_src(self, name, src):
+        if self.parser is not None:
+            tree = self.parser.parse(bytes(src, 'utf8'))
+            return self.build(name, tree, src)
+        # Fallback: extremely naive sequential blocks
+        return self._build_simple(name, src)
+
+    def build_from_file(self, name, filepath):
+        with open(filepath, 'r') as src_file:
+            src = src_file.read()
+        cfg = self.build_from_src(name, src)
+        return cfg
+
+    def build(self, name, tree, src):
+        self.src = src
+        self.cfg = CFG(name)
+        self.current_id = 0
+        self.current_block = self.new_block()
+        self.cfg.entryblock = self.current_block
+        root = tree.root_node
+        method = None
+        for child in root.named_children:
+            if child.type in ('function_declaration', 'method_definition'):
+                method = child
+                break
+        body = method.child_by_field_name('body') if method else root
+        if body.type in ('statement_block', 'block', 'compound_statement'):
+            self.visit_block(body)
+        else:
+            self.visit(body)
+        self.clean_cfg(self.cfg.entryblock)
+        return self.cfg
+
+    # Utility
+    def get_text(self, node):
+        return node.text.decode()
+
+    def invert(self, cond_text):
+        cond_text = cond_text.strip()
+        if cond_text.startswith('!'):
+            return cond_text[1:].strip()
+        return f'!({cond_text})'
+
+    # Clean cfg
+    def clean_cfg(self, block, visited=None):
+        if visited is None:
+            visited = []
+        if block in visited:
+            return
+        visited.append(block)
+        if block.is_empty():
+            for pred in list(block.predecessors):
+                for exit in list(block.exits):
+                    self.add_exit(pred.source, exit.target, exit.exitcase)
+                    if exit in exit.target.predecessors:
+                        exit.target.predecessors.remove(exit)
+                if pred in pred.source.exits:
+                    pred.source.exits.remove(pred)
+            for exit in list(block.exits):
+                self.clean_cfg(exit.target, visited)
+            block.predecessors = []
+            block.exits = []
+        else:
+            for exit in list(block.exits):
+                self.clean_cfg(exit.target, visited)
+
+    # Visitors
+    def visit(self, node):
+        method = getattr(self, f'visit_{node.type}', None)
+        if method is not None:
+            method(node)
+        else:
+            self.visit_generic(node)
+
+    def visit_generic(self, node):
+        self.add_statement(self.current_block, node)
+        if self.separate_node_blocks:
+            new = self.new_block()
+            self.add_exit(self.current_block, new)
+            self.current_block = new
+
+    def visit_block(self, node):
+        for child in node.named_children:
+            self.visit(child)
+
+    def visit_expression_statement(self, node):
+        self.add_statement(self.current_block, node)
+        if self.separate_node_blocks:
+            new = self.new_block()
+            self.add_exit(self.current_block, new)
+            self.current_block = new
+
+    visit_local_variable_declaration = visit_expression_statement
+
+    def visit_if_statement(self, node):
+        self.add_statement(self.current_block, node)
+        cond = node.child_by_field_name('condition')
+        cond_text = self.get_text(cond)
+        if_block = self.new_block()
+        self.add_exit(self.current_block, if_block, cond_text)
+        after_if = self.new_block()
+        alternative = node.child_by_field_name('alternative')
+        if alternative is not None:
+            else_block = self.new_block()
+            self.add_exit(self.current_block, else_block, self.invert(cond_text))
+            self.current_block = else_block
+            if alternative.type in ('statement_block', 'block', 'compound_statement'):
+                self.visit_block(alternative)
+            elif alternative.type == 'else_clause':
+                for child in alternative.named_children:
+                    self.visit(child)
+            else:
+                self.visit(alternative)
+            if not self.current_block.exits:
+                self.add_exit(self.current_block, after_if)
+        else:
+            self.add_exit(self.current_block, after_if, self.invert(cond_text))
+        self.current_block = if_block
+        consequence = node.child_by_field_name('consequence')
+        if consequence.type in ('statement_block', 'block', 'compound_statement'):
+            self.visit_block(consequence)
+        else:
+            self.visit(consequence)
+        if not self.current_block.exits:
+            self.add_exit(self.current_block, after_if)
+        self.current_block = after_if
+
+    def visit_while_statement(self, node):
+        loop_guard = self.new_loopguard()
+        self.current_block = loop_guard
+        self.add_statement(self.current_block, node)
+        cond = node.child_by_field_name('condition')
+        cond_text = self.get_text(cond)
+        self.curr_loop_guard_stack.append(loop_guard)
+        while_block = self.new_block()
+        self.add_exit(self.current_block, while_block, cond_text)
+        after_while = self.new_block()
+        self.after_loop_block_stack.append(after_while)
+        self.add_exit(self.current_block, after_while, self.invert(cond_text))
+        self.current_block = while_block
+        body = node.child_by_field_name('body')
+        if body.type in ('statement_block', 'block', 'compound_statement'):
+            self.visit_block(body)
+        else:
+            self.visit(body)
+        if not self.current_block.exits:
+            self.add_exit(self.current_block, loop_guard)
+        self.current_block = after_while
+        self.after_loop_block_stack.pop()
+        self.curr_loop_guard_stack.pop()
+
+    def visit_for_statement(self, node):
+        loop_guard = self.new_loopguard()
+        self.current_block = loop_guard
+        self.add_statement(self.current_block, node)
+        cond = node.child_by_field_name('condition')
+        cond_text = self.get_text(cond) if cond else None
+        self.curr_loop_guard_stack.append(loop_guard)
+        for_block = self.new_block()
+        if cond_text:
+            self.add_exit(self.current_block, for_block, cond_text)
+            after_for = self.new_block()
+            self.add_exit(self.current_block, after_for, self.invert(cond_text))
+        else:
+            self.add_exit(self.current_block, for_block)
+            after_for = self.new_block()
+            self.add_exit(self.current_block, after_for)
+        self.after_loop_block_stack.append(after_for)
+        self.current_block = for_block
+        body = node.child_by_field_name('body')
+        if body.type in ('statement_block', 'block', 'compound_statement'):
+            self.visit_block(body)
+        else:
+            self.visit(body)
+        if not self.current_block.exits:
+            self.add_exit(self.current_block, loop_guard)
+        self.current_block = after_for
+        self.after_loop_block_stack.pop()
+        self.curr_loop_guard_stack.pop()
+
+    visit_enhanced_for_statement = visit_for_statement
+
+    def visit_return_statement(self, node):
+        self.add_statement(self.current_block, node)
+        self.cfg.finalblocks.append(self.current_block)
+        self.current_block = self.new_block()
+
+    def visit_break_statement(self, node):
+        if self.after_switch_block_stack:
+            self.add_exit(self.current_block, self.after_switch_block_stack[-1])
+        elif self.after_loop_block_stack:
+            self.add_exit(self.current_block, self.after_loop_block_stack[-1])
+
+    def visit_continue_statement(self, node):
+        if self.curr_loop_guard_stack:
+            self.add_exit(self.current_block, self.curr_loop_guard_stack[-1])
+
+    # ------------------------------------------------------------------
+    # Fallback implementation
+    # ------------------------------------------------------------------
+    class _FakeNode:
+        """Minimal object mimicking the tree-sitter node API used by ``Block``."""
+
+        def __init__(self, text: str, line: int):
+            self.text = text.encode()
+            self.type = "statement"
+            self.start_point = (line, 0)
+
+    def _build_simple(self, name: str, src: str) -> CFG:
+        """Very naive CFG builder used when tree-sitter is unavailable."""
+        self.cfg = CFG(name)
+        self.current_id = 0
+        lines = []
+        start = src.find("{") + 1
+        end = src.rfind("}")
+        body = src[start:end]
+        for ln, line in enumerate(body.splitlines()):
+            stripped = line.strip()
+            if stripped:
+                lines.append((ln, stripped))
+
+        prev = None
+        for idx, (ln, stmt) in enumerate(lines):
+            block = self.new_block()
+            block.statements.append(self._FakeNode(stmt, ln))
+            if idx == 0:
+                self.cfg.entryblock = block
+            if prev is not None:
+                self.add_exit(prev, block)
+            prev = block
+        if prev is not None:
+            self.cfg.finalblocks.append(prev)
+        return self.cfg
+

--- a/javascript/model.py
+++ b/javascript/model.py
@@ -1,0 +1,141 @@
+"""Control flow graph classes for Go code."""
+
+import graphviz as gv
+
+class Block:
+    __slots__ = ["id", "statements", "func_calls", "predecessors", "exits"]
+
+    def __init__(self, id):
+        self.id = id
+        self.statements = []
+        self.func_calls = []
+        self.predecessors = []
+        self.exits = []
+
+    def __str__(self):
+        if self.statements:
+            return f"block:{self.id}@{self.at()}"
+        return f"empty block:{self.id}"
+
+    def __repr__(self):
+        txt = f"{str(self)} with {len(self.exits)} exits"
+        if self.statements:
+            txt += ", body=[" + ", ".join([s.type for s in self.statements]) + "]"
+        return txt
+
+    def at(self):
+        if self.statements:
+            return self.statements[0].start_point[0] + 1
+        return None
+
+    def is_empty(self):
+        return len(self.statements) == 0
+
+    def get_source(self):
+        src = ""
+        for stmt in self.statements:
+
+            text = stmt.text.decode()
+            if stmt.type in (
+                "if_statement",
+                "while_statement",
+                "for_statement",
+                "enhanced_for_statement",
+                "switch_expression",
+                "switch_statement",
+            ):
+                src += text.splitlines()[0] + "\n"
+            else:
+                src += text + "\n"
+
+        return src
+
+    def get_calls(self):
+        txt = ""
+        for func in self.func_calls:
+            txt += func + "\n"
+        return txt
+
+
+class Link:
+    __slots__ = ["source", "target", "exitcase"]
+
+    def __init__(self, source, target, exitcase=None):
+        assert isinstance(source, Block)
+        assert isinstance(target, Block)
+        self.source = source
+        self.target = target
+        self.exitcase = exitcase
+
+    def __str__(self):
+        return f"link from {self.source} to {self.target}"
+
+    def __repr__(self):
+        if self.exitcase is not None:
+            return f"{self}, with exitcase {self.exitcase}"
+        return str(self)
+
+    def get_exitcase(self):
+        return self.exitcase or ""
+
+
+class CFG:
+    def __init__(self, name, asynchr=False):
+        assert isinstance(name, str)
+        self.name = name
+        self.asynchr = asynchr
+        self.entryblock = None
+        self.finalblocks = []
+        self.functioncfgs = {}
+
+    def __str__(self):
+        return f"CFG for {self.name}"
+
+    def __iter__(self):
+        visited = set()
+        to_visit = [self.entryblock]
+        while to_visit:
+            block = to_visit.pop(0)
+            visited.add(block)
+            for exit_ in block.exits:
+                if exit_.target in visited or exit_.target in to_visit:
+                    continue
+                to_visit.append(exit_.target)
+            yield block
+        for subcfg in self.functioncfgs.values():
+            yield from subcfg
+
+    def _visit_blocks(self, graph, block, visited=None, calls=True):
+        if visited is None:
+            visited = []
+        if block.id in visited:
+            return
+
+        nodelabel = block.get_source()
+        graph.node(str(block.id), label=nodelabel)
+        visited.append(block.id)
+
+        if calls and block.func_calls:
+            calls_node = f"{block.id}_calls"
+            calls_label = block.get_calls().strip()
+            graph.node(calls_node, label=calls_label, _attributes={"shape": "box"})
+            graph.edge(str(block.id), calls_node, label="calls", _attributes={"style": "dashed"})
+
+        for exit in block.exits:
+            self._visit_blocks(graph, exit.target, visited, calls=calls)
+            edgelabel = exit.get_exitcase().strip()
+            graph.edge(str(block.id), str(exit.target.id), label=edgelabel)
+
+    def _build_visual(self, format="pdf", calls=True):
+        graph = gv.Digraph(name="cluster" + self.name, format=format, graph_attr={"label": self.name})
+        self._visit_blocks(graph, self.entryblock, visited=[], calls=calls)
+
+        for subcfg in self.functioncfgs:
+            subgraph = self.functioncfgs[subcfg]._build_visual(format=format, calls=calls)
+            graph.subgraph(subgraph)
+
+        return graph
+
+    def build_visual(self, filepath, format, calls=True, show=True):
+        graph = self._build_visual(format, calls)
+        graph.render(filepath, view=show)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(name='staticfg',
       author='Aurelien Coet',
       author_email='aurelien.coet19@gmail.com',
       description='Control flow graph generator for Python3 programs',
-      packages=['python', 'java', 'rust', 'go', 'c'],
+      packages=['python', 'java', 'javascript', 'rust', 'go', 'c'],
       test_suite='tests',
       install_requires=[
         'astor',


### PR DESCRIPTION
## Summary
- add a new `javascript` package with CFG builder and model
- integrate JavaScript into setup and analysis utilities
- document JavaScript usage in README

## Testing
- `python -c "import javascript; print('ok')"`
- `python - <<'EOF'
from javascript import CFGBuilder
cfg = CFGBuilder().build_from_file('foo','example.js')
for block in cfg:
    print('block', block.id, [s.type for s in block.statements])
print('exits:')
for block in cfg:
    for e in block.exits:
        print(e.source.id, '->', e.target.id)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_686d8753c8448330b48741bb992394de