### PR TITLE
Fix JS CFG builder for top-level code

### DIFF
--- a/javascript/cfg_builder.py
+++ b/javascript/cfg_builder.py
@@ -89,7 +89,7 @@ class CFGBuilder:
                 method = child
                 break
         body = method.child_by_field_name('body') if method else root
-        if body.type in ('statement_block', 'block', 'compound_statement'):
+        if body.type in ('statement_block', 'block', 'compound_statement', 'program'):
             self.visit_block(body)
         else:
             self.visit(body)
@@ -147,6 +147,8 @@ class CFGBuilder:
     def visit_block(self, node):
         for child in node.named_children:
             self.visit(child)
+
+    visit_program = visit_block
 
     def visit_expression_statement(self, node):
         self.add_statement(self.current_block, node)


### PR DESCRIPTION
## Summary
- handle root `program` nodes when building JavaScript CFGs
- support visiting `program` nodes like blocks so statements are parsed correctly

## Testing
- `python - <<'EOF'
from javascript.cfg_builder import CFGBuilder
code="""
        /// --- BLOCK BEGIN 13
if (class_var.root === null) {
    throw new Exception("Binary search tree is empty");
}
var node = class_var.root;
while (node.right !== null) {
    node = node.right;
}
return node.label;

        /// --- BLOCK END 13
"""
cfg=CFGBuilder().build_from_src('name', code)
for block in cfg:
    print('Block', block.id)
    for stmt in block.statements:
        print('\t', stmt.type, stmt.text.decode().strip())
    for exit in block.exits:
        print('\t->', exit.target.id, exit.exitcase)
EOF

------
https://chatgpt.com/codex/tasks/task_e_686d923126fc8330807539f6181db0fd